### PR TITLE
Vsc554- Cast mppt status to boolean

### DIFF
--- a/content/Clusters/Screen01.ui.qml
+++ b/content/Clusters/Screen01.ui.qml
@@ -315,7 +315,7 @@ Rectangle {
                         text: "Channel Number: " + mppt0.ChannelNumber
                     }
                     Text {
-                        text: "MPPT Status: " + (mppt0.MpptStatus === 128 ? "true" : "false")
+                        text: "MPPT Status: " + mppt0.MpptStatus
                     }
                     Text {
                         text: "Array Voltage: " + mppt0.ArrayVoltage
@@ -339,7 +339,7 @@ Rectangle {
                         text: "Channel Number: " + mppt1.ChannelNumber
                     }
                     Text {
-                        text: "MPPT Status: " + (mppt1.MpptStatus === 128 ? "true" : "false")
+                        text: "MPPT Status: " + mppt1.MpptStatus
                     }
                     Text {
                         text: "Array Voltage: " + mppt1.ArrayVoltage
@@ -363,7 +363,7 @@ Rectangle {
                         text: "Channel Number: " + mppt2.ChannelNumber
                     }
                     Text {
-                        text: "MPPT Status: " + (mppt2.MpptStatus === 128 ? "true" : "false")
+                        text: "MPPT Status: " + mppt2.MpptStatus
                     }
                     Text {
                         text: "Array Voltage: " + mppt2.ArrayVoltage
@@ -387,7 +387,7 @@ Rectangle {
                         text: "Channel Number: " + mppt3.ChannelNumber
                     }
                     Text {
-                        text: "MPPT Status: " + (mppt3.MpptStatus === 128 ? "true" : "false")
+                        text: "MPPT Status: " + mppt3.MpptStatus
                     }
                     Text {
                         text: "Array Voltage: " + mppt3.ArrayVoltage

--- a/content/Clusters/Screen01.ui.qml
+++ b/content/Clusters/Screen01.ui.qml
@@ -315,7 +315,7 @@ Rectangle {
                         text: "Channel Number: " + mppt0.ChannelNumber
                     }
                     Text {
-                        text: "MPPT Status: " + mppt0.MpptStatus
+                        text: "MPPT Status: " + (mppt0.MpptStatus === 128 ? "true" : "false")
                     }
                     Text {
                         text: "Array Voltage: " + mppt0.ArrayVoltage
@@ -339,7 +339,7 @@ Rectangle {
                         text: "Channel Number: " + mppt1.ChannelNumber
                     }
                     Text {
-                        text: "MPPT Status: " + mppt1.MpptStatus
+                        text: "MPPT Status: " + (mppt1.MpptStatus === 128 ? "true" : "false")
                     }
                     Text {
                         text: "Array Voltage: " + mppt1.ArrayVoltage
@@ -363,7 +363,7 @@ Rectangle {
                         text: "Channel Number: " + mppt2.ChannelNumber
                     }
                     Text {
-                        text: "MPPT Status: " + mppt2.MpptStatus
+                        text: "MPPT Status: " + (mppt2.MpptStatus === 128 ? "true" : "false")
                     }
                     Text {
                         text: "Array Voltage: " + mppt2.ArrayVoltage
@@ -387,7 +387,7 @@ Rectangle {
                         text: "Channel Number: " + mppt3.ChannelNumber
                     }
                     Text {
-                        text: "MPPT Status: " + mppt3.MpptStatus
+                        text: "MPPT Status: " + (mppt3.MpptStatus === 128 ? "true" : "false")
                     }
                     Text {
                         text: "Array Voltage: " + mppt3.ArrayVoltage

--- a/src/PacketFactory/Packets/MpptPacket.h
+++ b/src/PacketFactory/Packets/MpptPacket.h
@@ -7,7 +7,7 @@
 class MpptPacket : public IPacket {
     Q_OBJECT
     DEFINE_PROPERTY(unsigned char, ChannelNumber)
-    DEFINE_PROPERTY(unsigned char, MpptStatus)
+    DEFINE_PROPERTY(bool, MpptStatus)
 
     DEFINE_PROPERTY(unsigned short, ArrayVoltage)
     DEFINE_PROPERTY(unsigned short, ArrayCurrent)


### PR DESCRIPTION
- Old PR got canceled due to me renaming the branch name :( 

### CHANGES:
- Changed the type for Mppt Status to boolean and worked as intended. 
- Reverted old changes I did to qml file where I returned "true" or "false" depending if value was 128 or 0.