### PR TITLE
VSC607 3/4 gauge needle goes outside border on max value

### DIFF
--- a/content/Util/GaugeAnimation.qml
+++ b/content/Util/GaugeAnimation.qml
@@ -57,9 +57,11 @@ QtObject {
         ctx.lineWidth = needleWidth;
         ctx.strokeStyle = Config.needleColor;
 
-        var adjustedStartAngle = valueAngle + (needleWidth / (2 * Math.PI * arcRadius)) * 180;
+        var needleLength = 5;
 
-        var needleEndAngle = valueAngle - 0.05;
+        var needleStartAngle = valueAngle + (needleLength / (2 * Math.PI * arcRadius)) * 180;
+
+        var needleEndAngle = valueAngle - (needleLength / (2 * Math.PI * arcRadius)) * 180;
 
         var needleRadius = arcRadius - (needleWidth / 2);
 
@@ -67,7 +69,7 @@ QtObject {
             arcRadius,
             arcRadius,
             needleRadius,
-            degreesToRadians(adjustedStartAngle),
+            degreesToRadians(needleStartAngle),
             degreesToRadians(needleEndAngle),
             true
         );


### PR DESCRIPTION
Fixed drawGauge function in GaugeAnimation util file so needle doesn't go over at max value. Changed how needleStartAngle and needleEndAngle are calculated. 