### PR TITLE
VSC608 3/4 gauge text overlaps gauge when long

### DIFF
--- a/content/Clusters/RaceCluster.qml
+++ b/content/Clusters/RaceCluster.qml
@@ -109,8 +109,8 @@ Item {
 
     ThreeQuarterGauge {
         id: averageCellTempGauge
-        x: 181
-        y: 287
+        x: 178
+        y: 290
         minValue: 0
         maxValue: 100
         gaugeTitle: "AVG Cell Temp"

--- a/content/Config/Config.qml
+++ b/content/Config/Config.qml
@@ -21,7 +21,7 @@ QtObject {
 
     property int gaugeFontSizeS: 18
     property int gaugeFontSizeM: 24
-    property int gaugeFontSizeL: 36
+    property int gaugeFontSizeL: 28
 
     property int batteryFontSize: 18
 


### PR DESCRIPTION
Repositioned averageCellTempGauge so the needle doesn't overlap with the other gauges when value is min or max. Adjusted large font size in config so max value text doesn't overlap with the gauge. 